### PR TITLE
Added filename reference for PDF files

### DIFF
--- a/llama_index/readers/file/docs_reader.py
+++ b/llama_index/readers/file/docs_reader.py
@@ -37,7 +37,7 @@ class PDFReader(BaseReader):
                 page_text = pdf.pages[page].extract_text()
                 page_label = pdf.page_labels[page]
 
-                metadata = {"page_label": page_label}
+                metadata = {"page_label": page_label, "file_name":file.name}
                 if extra_info is not None:
                     metadata.update(extra_info)
 


### PR DESCRIPTION
In Case of loading multiple PDF files at once, We can use the file_name reference to specify user about the source file from which data is being extracted. 

Use Case: Provide Mendable like feature to provide the exact file from which response is generated.

Makes it easier for searching the Exact document using name reference