### PR TITLE
Adding name reference support for Docx reader

### DIFF
--- a/llama_index/readers/file/docs_reader.py
+++ b/llama_index/readers/file/docs_reader.py
@@ -61,5 +61,9 @@ class DocxReader(BaseReader):
             )
 
         text = docx2txt.process(file)
-
-        return [Document(text, extra_info=extra_info)]
+        metadata = {"file_name": file.name}
+        
+        if extra_info is not None:
+            metadata.update(extra_info)
+        
+        return [Document(text, extra_info=metadata)]


### PR DESCRIPTION
Helps to identify the doc more efficiently in case of multiple docs are added for creating indexes